### PR TITLE
Fix computed state type.

### DIFF
--- a/src/shared/Quark/Reactive/State.luau
+++ b/src/shared/Quark/Reactive/State.luau
@@ -4,7 +4,7 @@ local module = {
 	Created = {},
 }
 
-function module.new<T, R>(default: T? | (use: (Types.State<R>) -> R) -> T?, strict: boolean?): Types.State<T>
+function module.new<T>(default: T? | (use: <R>(Types.State<R>) -> R) -> T?, strict: boolean?): Types.State<T>
 	local self = setmetatable({
 		value = default,
 		strict = strict or false,


### PR DESCRIPTION
Currently, the default parameter for the State constructor doesn't have a correct type for the computed state. This should fix it.